### PR TITLE
add mkldnn surport for concat

### DIFF
--- a/src/common/utils.cc
+++ b/src/common/utils.cc
@@ -50,8 +50,8 @@ std::string stype_string(const int x) {
     case kRowSparseStorage:
       return "row_sparse";
 #if MXNET_USE_MKLDNN == 1
-	case kMKLDNNStorage:
-	  return "mkldnn";
+    case kMKLDNNStorage:
+      return "mkldnn";
 #endif
   }
   return "unknown";

--- a/src/executor/graph_executor.cc
+++ b/src/executor/graph_executor.cc
@@ -55,7 +55,11 @@ GraphExecutor::~GraphExecutor() {
 }
 
 inline bool SharableStorage(NDArrayStorageType stype) {
-  return stype == kDefaultStorage || stype == kMKLDNNStorage;
+  bool ret = stype == kDefaultStorage;
+#if MXNET_USE_MKLDNN == 1
+  ret = ret || stype == kMKLDNNStorage;
+#endif
+  return ret;
 }
 
 inline NDArray InitZeros(const NDArrayStorageType stype, const TShape &shape,

--- a/src/operator/nn/concat-inl.h
+++ b/src/operator/nn/concat-inl.h
@@ -23,8 +23,8 @@
  * \brief
  * \author Bing Xu
 */
-#ifndef MXNET_OPERATOR_CONCAT_INL_H_
-#define MXNET_OPERATOR_CONCAT_INL_H_
+#ifndef MXNET_OPERATOR_NN_CONCAT_INL_H_
+#define MXNET_OPERATOR_NN_CONCAT_INL_H_
 #include <dmlc/logging.h>
 #include <dmlc/parameter.h>
 #include <mxnet/operator.h>
@@ -156,4 +156,4 @@ void ConcatGradCompute(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
 }  // namespace op
 }  // namespace mxnet
 
-#endif  // MXNET_OPERATOR_CONCAT_INL_H_
+#endif  // MXNET_OPERATOR_NN_CONCAT_INL_H_

--- a/src/operator/nn/concat.cc
+++ b/src/operator/nn/concat.cc
@@ -153,14 +153,12 @@ void ConcatComputeExCPU(const nnvm::NodeAttrs& attrs,
   CHECK_EQ(req.size(), 1U);
   if (req[0] == kNullOp) return;
 #if MXNET_USE_MKLDNN == 1
-  //MKLDNN support 2D and 4D concat
+  // MKLDNN support 2D and 4D concat
   if (inputs[0].shape().ndim() == 2 || inputs[0].shape().ndim() == 4) {
-    if(inputs[0].dtype() == mshadow::kFloat32) { 
+    if (inputs[0].dtype() == mshadow::kFloat32) {
       MKLDNNConcat_Forward(attrs, op_ctx, inputs, req, outputs);
     }
-  }
-  else {
-    // TODO I need to convert format.
+  } else {
     std::vector<TBlob> in_blobs(inputs.size());
     for (size_t i = 0; i < in_blobs.size(); i++)
       in_blobs[i] = inputs[i].data();
@@ -177,12 +175,10 @@ static void ConcatGradComputeExCPU(const nnvm::NodeAttrs& attrs,
     const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
 #if MXNET_USE_MKLDNN == 1
   if (inputs[0].shape().ndim() == 2 || inputs[0].shape().ndim() == 4) {
-    if(inputs[0].dtype() == mshadow::kFloat32) { 
+    if (inputs[0].dtype() == mshadow::kFloat32) {
       MKLDNNConcat_Backward(attrs, ctx, inputs, req, outputs);
     }
-  }
-  else {
-    // TODO I need to convert format.
+  } else {
     std::vector<TBlob> in_blobs(1);
     in_blobs[0] = inputs[0].data();
     std::vector<TBlob> out_blobs(outputs.size());

--- a/src/operator/nn/concat.cc
+++ b/src/operator/nn/concat.cc
@@ -153,23 +153,12 @@ void ConcatComputeExCPU(const nnvm::NodeAttrs& attrs,
   CHECK_EQ(req.size(), 1U);
   if (req[0] == kNullOp) return;
 #if MXNET_USE_MKLDNN == 1
-<<<<<<< HEAD
   // MKLDNN support 2D and 4D concat
   if (inputs[0].shape().ndim() == 2 || inputs[0].shape().ndim() == 4) {
     if (inputs[0].dtype() == mshadow::kFloat32) {
       MKLDNNConcat_Forward(attrs, op_ctx, inputs, req, outputs);
     }
   } else {
-=======
-  //MKLDNN support 2D and 4D concat
-  if (inputs[0].shape().ndim() == 2 || inputs[0].shape().ndim() == 4) {
-    if(inputs[0].dtype() == mshadow::kFloat32) { 
-      MKLDNNConcat_Forward(attrs, op_ctx, inputs, req, outputs);
-    }
-  }
-  else {
-    // TODO I need to convert format.
->>>>>>> fca247d7db3ef8fc3e27dba030d6cb4d32d5fed0
     std::vector<TBlob> in_blobs(inputs.size());
     for (size_t i = 0; i < in_blobs.size(); i++)
       in_blobs[i] = inputs[i].data();
@@ -186,19 +175,10 @@ static void ConcatGradComputeExCPU(const nnvm::NodeAttrs& attrs,
     const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
 #if MXNET_USE_MKLDNN == 1
   if (inputs[0].shape().ndim() == 2 || inputs[0].shape().ndim() == 4) {
-<<<<<<< HEAD
     if (inputs[0].dtype() == mshadow::kFloat32) {
       MKLDNNConcat_Backward(attrs, ctx, inputs, req, outputs);
     }
   } else {
-=======
-    if(inputs[0].dtype() == mshadow::kFloat32) { 
-      MKLDNNConcat_Backward(attrs, ctx, inputs, req, outputs);
-    }
-  }
-  else {
-    // TODO I need to convert format.
->>>>>>> fca247d7db3ef8fc3e27dba030d6cb4d32d5fed0
     std::vector<TBlob> in_blobs(1);
     in_blobs[0] = inputs[0].data();
     std::vector<TBlob> out_blobs(outputs.size());

--- a/src/operator/nn/concat.cc
+++ b/src/operator/nn/concat.cc
@@ -25,6 +25,7 @@
 */
 
 #include "./concat-inl.h"
+#include "./mkldnn/mkldnn_ops-inl.h"
 
 namespace mxnet {
 namespace op {
@@ -103,12 +104,104 @@ static bool ConcatType(const nnvm::NodeAttrs& attrs,
   return true;
 }
 
+inline static bool ConcatForwardInferStorageType(const nnvm::NodeAttrs& attrs,
+                                 const int dev_mask,
+                                 DispatchMode* dispatch_mode,
+                                 std::vector<int> *in_attrs,
+                                 std::vector<int> *out_attrs) {
+  CHECK(!in_attrs->empty());
+  CHECK_EQ(out_attrs->size(), 1U);
+#if MXNET_USE_MKLDNN == 1
+  if (dev_mask == mshadow::cpu::kDevMask) {
+    *dispatch_mode = DispatchMode::kFComputeEx;
+    (*out_attrs)[0] = kMKLDNNStorage;
+    return true;
+  }
+#endif
+  *dispatch_mode = DispatchMode::kFCompute;
+  (*out_attrs)[0] = kDefaultStorage;
+  return true;
+}
+
+inline static bool backward_ConcatStorageType(const nnvm::NodeAttrs& attrs,
+                                          const int dev_mask,
+                                          DispatchMode* dispatch_mode,
+                                          std::vector<int> *in_attrs,
+                                          std::vector<int> *out_attrs) {
+#if MXNET_USE_MKLDNN == 1
+  CHECK_EQ(out_attrs->size(), in_attrs->size() - 1);
+  if (dev_mask == mshadow::cpu::kDevMask) {
+    *dispatch_mode = DispatchMode::kFComputeEx;
+    for (size_t i = 0; i < out_attrs->size(); i++)
+      (*out_attrs)[i] = kMKLDNNStorage;
+    return true;
+  }
+#endif
+  *dispatch_mode = DispatchMode::kFCompute;
+  for (size_t i = 0; i < out_attrs->size(); i++)
+    (*out_attrs)[i] = kDefaultStorage;
+  return true;
+}
+
+void ConcatComputeExCPU(const nnvm::NodeAttrs& attrs,
+                                const OpContext& op_ctx,
+                                const std::vector<NDArray>& inputs,
+                                const std::vector<OpReqType>& req,
+                                const std::vector<NDArray>& outputs) {
+  CHECK(!inputs.empty());
+  CHECK_EQ(outputs.size(), 1U);
+  CHECK_EQ(req.size(), 1U);
+  if (req[0] == kNullOp) return;
+#if MXNET_USE_MKLDNN == 1
+  //MKLDNN support 2D and 4D concat
+  if (inputs[0].shape().ndim() == 2 || inputs[0].shape().ndim() == 4) {
+    if(inputs[0].dtype() == mshadow::kFloat32) { 
+      MKLDNNConcat_Forward(attrs, op_ctx, inputs, req, outputs);
+    }
+  }
+  else {
+    // TODO I need to convert format.
+    std::vector<TBlob> in_blobs(inputs.size());
+    for (size_t i = 0; i < in_blobs.size(); i++)
+      in_blobs[i] = inputs[i].data();
+    std::vector<TBlob> out_blobs(outputs.size());
+    for (size_t i = 0; i < out_blobs.size(); i++)
+      out_blobs[i] = outputs[i].data();
+    ConcatCompute<cpu>(attrs, op_ctx, in_blobs, req, out_blobs);
+  }
+#endif
+}
+
+static void ConcatGradComputeExCPU(const nnvm::NodeAttrs& attrs,
+    const OpContext& ctx, const std::vector<NDArray>& inputs,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
+#if MXNET_USE_MKLDNN == 1
+  if (inputs[0].shape().ndim() == 2 || inputs[0].shape().ndim() == 4) {
+    if(inputs[0].dtype() == mshadow::kFloat32) { 
+      MKLDNNConcat_Backward(attrs, ctx, inputs, req, outputs);
+    }
+  }
+  else {
+    // TODO I need to convert format.
+    std::vector<TBlob> in_blobs(1);
+    in_blobs[0] = inputs[0].data();
+    std::vector<TBlob> out_blobs(outputs.size());
+    for (size_t i = 0; i < out_blobs.size(); i++)
+      out_blobs[i] = outputs[i].data();
+    ConcatGradCompute<cpu>(attrs, ctx, in_blobs, req, out_blobs);
+  }
+#endif
+}
+
 struct ConcatGrad {
   const char *op_name;
   std::vector<nnvm::NodeEntry> operator()(const nnvm::NodePtr& n,
                                           const std::vector<nnvm::NodeEntry>& ograds) const {
-    const ConcatParam& param = nnvm::get<ConcatParam>(n->attrs.parsed);
+    CHECK_EQ(ograds.size(), 1);
     std::vector<nnvm::NodeEntry> heads(ograds.begin(), ograds.end());
+    for (size_t i = 0; i < n->inputs.size(); i++) {
+      heads.push_back(n->inputs[i]);
+    }
     return MakeGradNode(op_name, n, heads, n->attrs.dict);
   }
 };
@@ -165,7 +258,9 @@ Example::
 })
 .set_attr<nnvm::FInferShape>("FInferShape", ConcatShape)
 .set_attr<nnvm::FInferType>("FInferType", ConcatType)
+.set_attr<FInferStorageType>("FInferStorageType", ConcatForwardInferStorageType)
 .set_attr<FCompute>("FCompute<cpu>", ConcatCompute<cpu>)
+.set_attr<FComputeEx>("FComputeEx<cpu>", ConcatComputeExCPU)
 .set_attr<nnvm::FGradient>("FGradient", ConcatGrad{"_backward_Concat"})
 .set_attr<std::string>("key_var_num_args", "num_args")
 .add_argument("data", "NDArray-or-Symbol[]", "List of arrays to concatenate")
@@ -180,7 +275,9 @@ NNVM_REGISTER_OP(_backward_Concat)
 })
 .set_attr_parser(ParamParser<ConcatParam>)
 .set_attr<nnvm::TIsBackward>("TIsBackward", true)
-.set_attr<FCompute>("FCompute<cpu>", ConcatGradCompute<cpu>);
+.set_attr<FInferStorageType>("FInferStorageType", backward_ConcatStorageType)
+.set_attr<FCompute>("FCompute<cpu>", ConcatGradCompute<cpu>)
+.set_attr<FComputeEx>("FComputeEx<cpu>", ConcatGradComputeExCPU);
 
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/nn/convolution.cc
+++ b/src/operator/nn/convolution.cc
@@ -57,7 +57,6 @@ static void ConvolutionCompute_CPU(const nnvm::NodeAttrs& attrs,
     return;
   }
 #endif
-  // TODO I need to convert format.
   std::vector<TBlob> in_blobs(inputs.size());
   for (size_t i = 0; i < in_blobs.size(); i++)
     in_blobs[i] = inputs[i].data();
@@ -76,7 +75,6 @@ static void ConvolutionGradCompute_CPU(const nnvm::NodeAttrs& attrs,
     return;
   }
 #endif
-  // TODO I need to convert format.
   std::vector<TBlob> in_blobs(inputs.size());
   for (size_t i = 0; i < in_blobs.size(); i++)
     in_blobs[i] = inputs[i].data();

--- a/src/operator/nn/cudnn/cudnn_deconvolution-inl.h
+++ b/src/operator/nn/cudnn/cudnn_deconvolution-inl.h
@@ -216,7 +216,7 @@ class CuDNNDeconvolutionOp {
     DType *data_ptr = NULL;
     DType *gdata_ptr = NULL;
     CHECK_EQ(out_grad.size(), 1U);
-    CHECK_EQ(in_data.size(), 2U);
+    CHECK_EQ(in_data.size(), param_.no_bias ? 2U : 3U);
     CHECK_EQ(in_grad.size(), expected);
     Stream<gpu> *s = ctx.get_stream<gpu>();
     if (param_.kernel.ndim() == 2) {
@@ -247,6 +247,7 @@ class CuDNNDeconvolutionOp {
       CHECK_NE(req[deconv::kBias], kWriteInplace);
     }
     CHECK_NE(req[deconv::kData], kWriteInplace);
+    GetTempSize(ctx);
     Tensor<gpu, 1, DType> workspace = AllocateTempWorkspace(ctx, backward_workspace_byte_);
     size_t workspace_size = TensorSizeBytes(workspace);
     for (uint32_t g = 0; g < param_.num_group; ++g) {

--- a/src/operator/nn/deconvolution.cc
+++ b/src/operator/nn/deconvolution.cc
@@ -285,7 +285,11 @@ inline static bool backward_DeconvStorageType(const nnvm::NodeAttrs& attrs,
                                           std::vector<int> *out_attrs) {
   const DeconvolutionParam& param = nnvm::get<DeconvolutionParam>(attrs.parsed);
   uint32_t out_expected = param.no_bias ? 2 : 3;
+#if MXNET_USE_CUDNN == 1
+  CHECK_EQ(in_attrs->size(), param.no_bias ? 3U : 4U);
+#else
   CHECK_EQ(in_attrs->size(), 3U);
+#endif
   CHECK_EQ(out_attrs->size(), out_expected);
 
 #if MXNET_USE_MKLDNN == 1
@@ -374,6 +378,11 @@ struct DeconvolutionGrad {
     std::vector<nnvm::NodeEntry> heads(ograds.begin(), ograds.end());
     heads.push_back(n->inputs[deconv::kData]);
     heads.push_back(n->inputs[deconv::kWeight]);
+#if MXNET_USE_CUDNN == 1
+    const DeconvolutionParam& param = nnvm::get<DeconvolutionParam>(n->attrs.parsed);
+    if (!param.no_bias)
+      heads.push_back(n->inputs[deconv::kBias]);
+#endif
     return MakeGradNode(op_name, n, heads, n->attrs.dict);
   }
 };

--- a/src/operator/nn/deconvolution.cc
+++ b/src/operator/nn/deconvolution.cc
@@ -315,7 +315,6 @@ static void DeconvolutionCompute_CPU(const nnvm::NodeAttrs& attrs,
     return;
   }
 #endif
-  // TODO I need to convert format.
   std::vector<TBlob> in_blobs(inputs.size());
   for (size_t i = 0; i < in_blobs.size(); i++)
     in_blobs[i] = inputs[i].data();
@@ -334,7 +333,6 @@ static void DeconvolutionGradCompute_CPU(const nnvm::NodeAttrs& attrs,
     return;
   }
 #endif
-  // TODO I need to convert format.
   std::vector<TBlob> in_blobs(inputs.size());
   for (size_t i = 0; i < in_blobs.size(); i++)
     in_blobs[i] = inputs[i].data();

--- a/src/operator/nn/deconvolution.cu
+++ b/src/operator/nn/deconvolution.cu
@@ -39,13 +39,9 @@ static CuDNNDeconvolutionOp<DType> &GetCuDNNDeconvOp(const DeconvolutionParam& p
                                                      int backward_compute_type,
                                                      const std::vector<TShape>& in_shape,
                                                      const std::vector<TShape>& out_shape,
-                                                     const Context& ctx, bool backward) {
-  // Convolution forward has to be called before backward for this operator.
-  // So we can't make this operator thread local. backward might be called
-  // in another thread.
-  static CuDNNDeconvolutionOp<DType> op;
-  if (!backward)
-    op.Init(param, forward_compute_type, backward_compute_type, in_shape, out_shape, ctx);
+                                                     const Context& ctx) {
+  static thread_local CuDNNDeconvolutionOp<DType> op;
+  op.Init(param, forward_compute_type, backward_compute_type, in_shape, out_shape, ctx);
   return op;
 }
 #endif
@@ -90,7 +86,7 @@ void DeconvolutionCompute<gpu>(const nnvm::NodeAttrs& attrs,
         in_shape[i] = inputs[i].shape_;
       }
       GetCuDNNDeconvOp<DType>(param, compute_type, compute_type,
-          in_shape, out_shape, ctx.run_ctx.ctx, false).Forward(ctx, inputs, req, outputs);
+          in_shape, out_shape, ctx.run_ctx.ctx).Forward(ctx, inputs, req, outputs);
     }
   })
 #else
@@ -146,7 +142,7 @@ void DeconvolutionGradCompute<gpu>(const nnvm::NodeAttrs& attrs,
         in_shape[i] = in_data[i].shape_;
       }
       GetCuDNNDeconvOp<DType>(param, compute_type, compute_type,
-          in_shape, out_shape, ctx.run_ctx.ctx, true).Backward(ctx,
+          in_shape, out_shape, ctx.run_ctx.ctx).Backward(ctx,
             std::vector<TBlob>{out_grad}, in_data, req, in_grad);
     }
   })

--- a/src/operator/nn/fully_connected.cc
+++ b/src/operator/nn/fully_connected.cc
@@ -82,7 +82,6 @@ void FullyConnectedCompute_CPU(const nnvm::NodeAttrs& attrs, const OpContext &ct
     return;
   }
 #endif
-  // TODO I need to convert format.
   std::vector<TBlob> in_blobs(inputs.size());
   for (size_t i = 0; i < in_blobs.size(); i++)
     in_blobs[i] = inputs[i].data();
@@ -101,7 +100,6 @@ void FullyConnectedGradCompute_CPU(const nnvm::NodeAttrs& attrs,
     return;
   }
 #endif
-  // TODO I need to convert format.
   std::vector<TBlob> in_blobs(inputs.size());
   for (size_t i = 0; i < in_blobs.size(); i++)
     in_blobs[i] = inputs[i].data();

--- a/src/operator/nn/lrn-inl.h
+++ b/src/operator/nn/lrn-inl.h
@@ -23,8 +23,8 @@
  * \brief
  * \author Bing Xu
 */
-#ifndef MXNET_OPERATOR_LRN_INL_H_
-#define MXNET_OPERATOR_LRN_INL_H_
+#ifndef MXNET_OPERATOR_NN_LRN_INL_H_
+#define MXNET_OPERATOR_NN_LRN_INL_H_
 #include <dmlc/logging.h>
 #include <dmlc/parameter.h>
 #include <mxnet/operator.h>
@@ -124,4 +124,4 @@ void LRNGradCompute(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
 
 }  // namespace op
 }  // namespace mxnet
-#endif  // MXNET_OPERATOR_LRN_INL_H_
+#endif  // MXNET_OPERATOR_NN_LRN_INL_H_

--- a/src/operator/nn/lrn.cc
+++ b/src/operator/nn/lrn.cc
@@ -70,7 +70,7 @@ struct LRNGrad {
   std::vector<nnvm::NodeEntry> operator()(const nnvm::NodePtr& n,
                                           const std::vector<nnvm::NodeEntry>& ograds) const {
     std::vector<nnvm::NodeEntry> heads;
-    heads.push_back(ograds[0]); // out_grad
+    heads.push_back(ograds[0]);  // out_grad
     heads.push_back(n->inputs[lrn_enum::kData]);
     heads.emplace_back(nnvm::NodeEntry{n, lrn_enum::kTmpNorm, 0});
     return MakeGradNode(op_name, n, heads, n->attrs.dict);

--- a/src/operator/nn/lrn.cc
+++ b/src/operator/nn/lrn.cc
@@ -25,9 +25,6 @@
 */
 
 #include "./lrn-inl.h"
-#if MXNET_USE_CUDNN == 1
-#include "./cudnn_lrn-inl.h"
-#endif
 
 namespace mxnet {
 namespace op {

--- a/src/operator/nn/lrn.cu
+++ b/src/operator/nn/lrn.cu
@@ -25,9 +25,6 @@
 */
 
 #include "./lrn-inl.h"
-#if MXNET_USE_CUDNN == 1
-#include "./cudnn_lrn-inl.h"
-#endif
 
 namespace mxnet {
 namespace op {

--- a/src/operator/nn/mkldnn/mkldnn_act-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_act-inl.h
@@ -23,8 +23,8 @@
  * \author Da Zheng
 */
 
-#ifndef MXNET_OPERATOR_MKL_MKLDNN_ACT_INL_H_
-#define MXNET_OPERATOR_MKL_MKLDNN_ACT_INL_H_
+#ifndef MXNET_OPERATOR_NN_MKLDNN_MKLDNN_ACT_INL_H_
+#define MXNET_OPERATOR_NN_MKLDNN_MKLDNN_ACT_INL_H_
 
 
 #include <dmlc/logging.h>
@@ -80,10 +80,10 @@ void MKLDNNAct_Forward(const OpContext &ctx, const ActivationParam& param,
 
   auto alg = GetMKLDNNActAlgo(param);
   mkldnn::eltwise_forward::desc desc = ctx.is_train
-    ? mkldnn::eltwise_forward::desc(mkldnn::prop_kind::forward_training,
-        alg, data_md, alpha)
-    : mkldnn::eltwise_forward::desc(mkldnn::prop_kind::forward_scoring,
-	alg, data_md, alpha);
+      ? mkldnn::eltwise_forward::desc(mkldnn::prop_kind::forward_training,
+                                      alg, data_md, alpha)
+      : mkldnn::eltwise_forward::desc(mkldnn::prop_kind::forward_scoring,
+                                      alg, data_md, alpha);
   mkldnn::eltwise_forward::primitive_desc pdesc(desc, cpu_engine);
 
   std::shared_ptr<const mkldnn::memory> output_memory
@@ -128,4 +128,4 @@ void MKLDNNAct_Backward(const OpContext &ctx, const ActivationParam& param,
 }  // namespace mxnet
 
 #endif
-#endif  // MXNET_OPERATOR_MKL_MKLDNN_ACT_INL_H_
+#endif  // MXNET_OPERATOR_NN_MKLDNN_MKLDNN_ACT_INL_H_

--- a/src/operator/nn/mkldnn/mkldnn_concat.cc
+++ b/src/operator/nn/mkldnn/mkldnn_concat.cc
@@ -38,21 +38,13 @@ void MKLDNNConcat_Forward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
   int concat_dim = param.dim;
   std::vector<mkldnn::memory::primitive_desc> data_md;
   std::vector<mkldnn::primitive::at> data_mem;
-<<<<<<< HEAD
   for (int i =0; i < num_in_data; i++) {
-=======
-  for(int i =0; i < num_in_data; i++) {
->>>>>>> fca247d7db3ef8fc3e27dba030d6cb4d32d5fed0
       std::shared_ptr<const mkldnn::memory> tmp_mem = in_data[i].GetMKLDNNData();
       auto tmp_pd = tmp_mem->get_primitive_desc();
       data_md.push_back(tmp_pd);
       data_mem.push_back(*tmp_mem);
   }
-<<<<<<< HEAD
   mkldnn::concat::primitive_desc fwd_pd(concat_dim, data_md);
-=======
-  mkldnn::concat::primitive_desc fwd_pd(concat_dim, data_md); 
->>>>>>> fca247d7db3ef8fc3e27dba030d6cb4d32d5fed0
   auto engine = CpuEngine::Instance().get_engine();
   auto out_mem = CreateMKLDNNMem(out_data[concat_enum::kOut],
       fwd_pd.dst_primitive_desc(), req[concat_enum::kOut]);
@@ -69,47 +61,28 @@ void MKLDNNConcat_Backward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
   int axis_ = param.dim;
   auto engine = CpuEngine::Instance().get_engine();
   std::shared_ptr<const mkldnn::memory>gz_mem = inputs[0].GetMKLDNNData();
-<<<<<<< HEAD
   mkldnn::memory::primitive_desc gz_pd = gz_mem->get_primitive_desc();
   /* init the offset */
   mkldnn::memory::dims offsets = {0, 0, 0, 0};
   for (int i = 0; i < num_in_data; i++) {
       mkldnn::memory::dims diff_src_tz = {inputs[i+1].shape()[0], inputs[i+1].shape()[1],
           inputs[i+1].shape()[2], inputs[i+1].shape()[3]};
-=======
-  mkldnn::memory::primitive_desc gz_pd = gz_mem->get_primitive_desc(); 
-  /* init the offset */
-  mkldnn::memory::dims offsets = {0, 0, 0, 0};
-  for (int i = 0; i < num_in_data; i++) {
-      mkldnn::memory::dims diff_src_tz = {inputs[i+1].shape()[0], inputs[i+1].shape()[1], inputs[i+1].shape()[2], inputs[i+1].shape()[3]};
->>>>>>> fca247d7db3ef8fc3e27dba030d6cb4d32d5fed0
       auto diff_src_mpd = inputs[i+1].GetMKLDNNData()->get_primitive_desc();
       auto gradi_mem_ = CreateMKLDNNMem(outputs[i], diff_src_mpd, req[i]);
       // create view from gy to gxs[i]
       std::shared_ptr<mkldnn::view::primitive_desc> view_pd;
       view_pd.reset(new mkldnn::view::primitive_desc(gz_pd, diff_src_tz, offsets));
       // create reorder primitive from gy to gxs[i]
-<<<<<<< HEAD
       mkldnn::reorder::primitive_desc reorder_pd(
           view_pd.get()->dst_primitive_desc(), diff_src_mpd);
       offsets[axis_] += diff_src_tz[axis_];
       MKLDNNStream::Instance().RegisterPrim(mkldnn::reorder(
           reorder_pd, *gz_mem, *gradi_mem_.second));
-=======
-      mkldnn::reorder::primitive_desc reorder_pd(view_pd.get()->dst_primitive_desc(), diff_src_mpd);
-      offsets[axis_] += diff_src_tz[axis_];
-      MKLDNNStream::Instance().RegisterPrim(mkldnn::reorder(reorder_pd, *gz_mem, *gradi_mem_.second));
->>>>>>> fca247d7db3ef8fc3e27dba030d6cb4d32d5fed0
       CommitOutput(outputs[i], gradi_mem_);
   }
   MKLDNNStream::Instance().Submit();
 }
 
-<<<<<<< HEAD
 }  // namespace op
 }  // namespace mxnet
-=======
-}//op
-}//mxnet
->>>>>>> fca247d7db3ef8fc3e27dba030d6cb4d32d5fed0
 #endif

--- a/src/operator/nn/mkldnn/mkldnn_concat.cc
+++ b/src/operator/nn/mkldnn/mkldnn_concat.cc
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file mkldnn_concat.cc
+ * \brief
+ * \author Wenting Jiang
+*/
+#include "../concat-inl.h"
+#include "./mkldnn_ops-inl.h"
+#include "./mkldnn_base-inl.h"
+
+#if MXNET_USE_MKLDNN == 1
+namespace mxnet {
+namespace op {
+
+void MKLDNNConcat_Forward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
+    const std::vector<NDArray> &in_data, const std::vector<OpReqType> &req,
+    const std::vector<NDArray> &out_data) {
+  const ConcatParam& param = nnvm::get<ConcatParam>(attrs.parsed);
+  int num_in_data = param.num_args;
+  int concat_dim = param.dim;
+  std::vector<mkldnn::memory::primitive_desc> data_md;
+  std::vector<mkldnn::primitive::at> data_mem;
+  for(int i =0; i < num_in_data; i++) {
+      std::shared_ptr<const mkldnn::memory> tmp_mem = in_data[i].GetMKLDNNData();
+      auto tmp_pd = tmp_mem->get_primitive_desc();
+      data_md.push_back(tmp_pd);
+      data_mem.push_back(*tmp_mem);
+  }
+  mkldnn::concat::primitive_desc fwd_pd(concat_dim, data_md); 
+  auto engine = CpuEngine::Instance().get_engine();
+  auto out_mem = CreateMKLDNNMem(out_data[concat_enum::kOut],
+      fwd_pd.dst_primitive_desc(), req[concat_enum::kOut]);
+  MKLDNNStream::Instance().RegisterPrim(mkldnn::concat(fwd_pd, data_mem, *out_mem.second));
+  CommitOutput(out_data[concat_enum::kOut], out_mem);
+  MKLDNNStream::Instance().Submit();
+}
+
+void MKLDNNConcat_Backward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
+    const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+    const std::vector<NDArray>& outputs) {
+  const ConcatParam& param = nnvm::get<ConcatParam>(attrs.parsed);
+  int num_in_data = param.num_args;
+  int axis_ = param.dim;
+  auto engine = CpuEngine::Instance().get_engine();
+  std::shared_ptr<const mkldnn::memory>gz_mem = inputs[0].GetMKLDNNData();
+  mkldnn::memory::primitive_desc gz_pd = gz_mem->get_primitive_desc(); 
+  /* init the offset */
+  mkldnn::memory::dims offsets = {0, 0, 0, 0};
+  for (int i = 0; i < num_in_data; i++) {
+      mkldnn::memory::dims diff_src_tz = {inputs[i+1].shape()[0], inputs[i+1].shape()[1], inputs[i+1].shape()[2], inputs[i+1].shape()[3]};
+      auto diff_src_mpd = inputs[i+1].GetMKLDNNData()->get_primitive_desc();
+      auto gradi_mem_ = CreateMKLDNNMem(outputs[i], diff_src_mpd, req[i]);
+      // create view from gy to gxs[i]
+      std::shared_ptr<mkldnn::view::primitive_desc> view_pd;
+      view_pd.reset(new mkldnn::view::primitive_desc(gz_pd, diff_src_tz, offsets));
+      // create reorder primitive from gy to gxs[i]
+      mkldnn::reorder::primitive_desc reorder_pd(view_pd.get()->dst_primitive_desc(), diff_src_mpd);
+      offsets[axis_] += diff_src_tz[axis_];
+      MKLDNNStream::Instance().RegisterPrim(mkldnn::reorder(reorder_pd, *gz_mem, *gradi_mem_.second));
+      CommitOutput(outputs[i], gradi_mem_);
+  }
+  MKLDNNStream::Instance().Submit();
+}
+
+}//op
+}//mxnet
+#endif

--- a/src/operator/nn/mkldnn/mkldnn_copy.cc
+++ b/src/operator/nn/mkldnn/mkldnn_copy.cc
@@ -46,13 +46,12 @@ void MKLDNNCopy(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
     MKLDNNStream::Instance().RegisterMem(sum_res);
     Sum(*in_mem, *out_mem, *sum_res);
     const_cast<NDArray &>(out_data).CopyFrom(*sum_res);
-  }
-  else {
+  } else {
     const_cast<NDArray &>(out_data).CopyFrom(*in_mem);
   }
   MKLDNNStream::Instance().Submit();
 }
 
-}
-}
+}   // namespace op
+}   // namespace mxnet
 #endif

--- a/src/operator/nn/mkldnn/mkldnn_deconvolution.cc
+++ b/src/operator/nn/mkldnn/mkldnn_deconvolution.cc
@@ -50,8 +50,7 @@ static mkldnn::convolution_forward::primitive_desc GetDeconvBwd_(
         mkldnn::algorithm::convolution_direct, out_md, weights_md, data_md, strides,
         dilates, padding, padding, mkldnn::padding_kind::zero);
     return mkldnn::convolution_forward::primitive_desc(desc, engine);
-  }
-  else {
+  } else {
     auto bias_md = GetBiasDesc(data_md);
     mkldnn::convolution_forward::desc desc(mkldnn::prop_kind::forward_training,
         mkldnn::algorithm::convolution_direct, out_md, weights_md, bias_md,
@@ -143,8 +142,7 @@ static mkldnn::convolution_backward_weights::primitive_desc GetDeconvBwdWeights(
     mkldnn::convolution_backward_weights::desc desc(mkldnn::algorithm::convolution_direct,
         out_md, weight_md, data_md, strides, dilate, padding, padding, mkldnn::padding_kind::zero);
     return mkldnn::convolution_backward_weights::primitive_desc(desc, engine, fwd_pd);
-  }
-  else {
+  } else {
     auto bias_md = GetBiasDesc(data_md);
     mkldnn::convolution_backward_weights::desc desc(mkldnn::algorithm::convolution_direct,
         out_md, weight_md, bias_md, data_md, strides, dilate, padding, padding,
@@ -232,7 +230,7 @@ void MKLDNNDeconvolution_Backward(const nnvm::NodeAttrs& attrs, const OpContext 
   }
 }
 
-}
-}
+}  // namespace op
+}  // namespace mxnet
 
-#endif // MXNET_USE_MKLDNN == 1
+#endif  // MXNET_USE_MKLDNN == 1

--- a/src/operator/nn/mkldnn/mkldnn_fully_connected.cc
+++ b/src/operator/nn/mkldnn/mkldnn_fully_connected.cc
@@ -41,8 +41,7 @@ inline static mkldnn::inner_product_forward::primitive_desc GetIPFwd(
     mkldnn::inner_product_forward::desc ipFwd_desc(mkldnn::prop_kind::forward_training,
         data_md, weight_md, bias_md, out_md);
     return mkldnn::inner_product_forward::primitive_desc(ipFwd_desc, engine);
-  }
-  else {
+  } else {
     mkldnn::inner_product_forward::desc ipFwd_desc(mkldnn::prop_kind::forward_training,
         data_md, weight_md, out_md);
     return mkldnn::inner_product_forward::primitive_desc(ipFwd_desc, engine);
@@ -73,8 +72,7 @@ inline static mkldnn::inner_product_backward_weights::primitive_desc GetIPBwdWei
         weight_md, bias_md, out_md);
     return mkldnn::inner_product_backward_weights::primitive_desc(
         ipBwdWeights_desc, engine, ipFwd_pd);
-  }
-  else {
+  } else {
     mkldnn::inner_product_backward_weights::desc ipBwdWeights_desc(data_md,
         weight_md, out_md);
     return mkldnn::inner_product_backward_weights::primitive_desc(
@@ -94,16 +92,14 @@ void MKLDNNFC_Forward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
   if (data.shape().ndim() != 2 && !param.flatten) {
     data = data.ReshapeMKLDNN(Shape2(ishape.ProdShape(0, ishape.ndim()-1),
                                      ishape[ishape.ndim()-1]));
-    // TODO this can potentially be a problem when casting the type.
-    mkldnn::memory::dims out_dims{(int) oshape.ProdShape(0, oshape.ndim()-1),
-      (int) oshape[ishape.ndim()-1]};
+    mkldnn::memory::dims out_dims{static_cast<int>(oshape.ProdShape(0, oshape.ndim()-1)),
+      static_cast<int>(oshape[ishape.ndim()-1])};
     out_md = mkldnn::memory::desc(out_dims, get_mkldnn_type(out_data[fullc::kOut].dtype()),
       mkldnn::memory::format::any);
-  }
-  else if (data.shape().ndim() != 2) {
+  } else if (data.shape().ndim() != 2) {
     data = data.ReshapeMKLDNN(Shape2(ishape[0], ishape.ProdShape(1, ishape.ndim())));
-    // TODO this can potentially be a problem when casting the type.
-    mkldnn::memory::dims out_dims{(int) oshape[0], (int) oshape.ProdShape(1, oshape.ndim())};
+    mkldnn::memory::dims out_dims{static_cast<int>(oshape[0]),
+      static_cast<int>(oshape.ProdShape(1, oshape.ndim()))};
     out_md = mkldnn::memory::desc(out_dims, get_mkldnn_type(out_data[fullc::kOut].dtype()),
       mkldnn::memory::format::any);
   }
@@ -192,6 +188,6 @@ void MKLDNNFC_Backward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
   MKLDNNStream::Instance().Submit();
 }
 
-}
-}
+}  // namespace op
+}  // namespace mxnet
 #endif  // MXNET_USE_MKLDNN == 1

--- a/src/operator/nn/mkldnn/mkldnn_ops-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_ops-inl.h
@@ -77,8 +77,16 @@ void MKLDNNCopy(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
                 const NDArray &in_data, const OpReqType &req,
                 const NDArray &out_data);
 
-}  // namespace op
-}  // namespace mxnet
+/* For concat */
+void MKLDNNConcat_Forward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
+    const std::vector<NDArray> &in_data, const std::vector<OpReqType> &req,
+    const std::vector<NDArray> &out_data);
+void MKLDNNConcat_Backward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
+    const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+    const std::vector<NDArray>& outputs);
+
+}
+}
 #endif  // MXNET_USE_MKLDNN == 1
 
 #endif  // MXNET_OPERATOR_NN_MKLDNN_MKLDNN_OPS_INL_H_

--- a/src/operator/nn/mkldnn/mkldnn_ops-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_ops-inl.h
@@ -76,6 +76,14 @@ void MKLDNNCopy(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
                 const NDArray &in_data, const OpReqType &req,
                 const NDArray &out_data);
 
+/* For concat */
+void MKLDNNConcat_Forward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
+    const std::vector<NDArray> &in_data, const std::vector<OpReqType> &req,
+    const std::vector<NDArray> &out_data);
+void MKLDNNConcat_Backward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
+    const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+    const std::vector<NDArray>& outputs);
+
 }
 }
 #endif  // MXNET_USE_MKLDNN == 1

--- a/src/operator/nn/mkldnn/mkldnn_ops-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_ops-inl.h
@@ -85,21 +85,8 @@ void MKLDNNConcat_Backward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
     const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
     const std::vector<NDArray>& outputs);
 
-<<<<<<< HEAD
 }  // namespace op
 }  // namespace mxnet
-=======
-/* For concat */
-void MKLDNNConcat_Forward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
-    const std::vector<NDArray> &in_data, const std::vector<OpReqType> &req,
-    const std::vector<NDArray> &out_data);
-void MKLDNNConcat_Backward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
-    const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
-    const std::vector<NDArray>& outputs);
-
-}
-}
->>>>>>> fca247d7db3ef8fc3e27dba030d6cb4d32d5fed0
 #endif  // MXNET_USE_MKLDNN == 1
 
 #endif  // MXNET_OPERATOR_NN_MKLDNN_MKLDNN_OPS_INL_H_

--- a/src/operator/nn/mkldnn/mkldnn_ops-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_ops-inl.h
@@ -74,8 +74,8 @@ void MKLDNNSum_Forward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
 
 /* For copy */
 void MKLDNNCopy(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
-                const NDArray &in_data, const OpReqType &req,
-                const NDArray &out_data);
+    const NDArray &in_data, const OpReqType &req,
+    const NDArray &out_data);
 
 /* For concat */
 void MKLDNNConcat_Forward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
@@ -85,8 +85,8 @@ void MKLDNNConcat_Backward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
     const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
     const std::vector<NDArray>& outputs);
 
-}
-}
+}  // namespace op
+}  // namespace mxnet
 #endif  // MXNET_USE_MKLDNN == 1
 
 #endif  // MXNET_OPERATOR_NN_MKLDNN_MKLDNN_OPS_INL_H_

--- a/src/operator/nn/mkldnn/mkldnn_ops-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_ops-inl.h
@@ -23,7 +23,6 @@
  * \author Da Zheng
 */
 
-#include <mkldnn.hpp>
 #include <mxnet/io.h>
 #include <mxnet/base.h>
 #include <mxnet/ndarray.h>
@@ -31,6 +30,8 @@
 #include <mxnet/operator_util.h>
 #include <dmlc/logging.h>
 #include <dmlc/optional.h>
+#include <vector>
+#include <mkldnn.hpp>
 
 #ifndef MXNET_OPERATOR_NN_MKLDNN_MKLDNN_OPS_INL_H_
 #define MXNET_OPERATOR_NN_MKLDNN_MKLDNN_OPS_INL_H_
@@ -76,8 +77,8 @@ void MKLDNNCopy(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
                 const NDArray &in_data, const OpReqType &req,
                 const NDArray &out_data);
 
-}
-}
+}  // namespace op
+}  // namespace mxnet
 #endif  // MXNET_USE_MKLDNN == 1
 
 #endif  // MXNET_OPERATOR_NN_MKLDNN_MKLDNN_OPS_INL_H_

--- a/src/operator/nn/mkldnn/mkldnn_softmax.cc
+++ b/src/operator/nn/mkldnn/mkldnn_softmax.cc
@@ -50,6 +50,6 @@ void MKLDNNSoftmax_Forward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
   stream.Submit();
 }
 
-}
-}
+}   // namespace op
+}   // namespace mxnet
 #endif

--- a/src/operator/nn/mkldnn/mkldnn_sum.cc
+++ b/src/operator/nn/mkldnn/mkldnn_sum.cc
@@ -43,6 +43,7 @@ void Sum(const mkldnn::memory &arr1, const mkldnn::memory &arr2,
   scales[1] = 1;
   inputs.push_back(arr1);
   inputs.push_back(arr2);
+  // TODO(zhengda) I need to reorder memory here.
   mkldnn::sum::primitive_desc sum_pd(scales, input_pds);
   MKLDNNStream::Instance().RegisterPrim(mkldnn::sum(sum_pd, inputs, out));
 }
@@ -68,6 +69,6 @@ void MKLDNNSum_Forward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
   stream.Submit();
 }
 
-}
-}
+}  // namespace op
+}  // namespace mxnet
 #endif

--- a/src/operator/nn/pooling.cc
+++ b/src/operator/nn/pooling.cc
@@ -114,7 +114,7 @@ static bool PoolingShape(const nnvm::NodeAttrs &attrs,
     out_shape->push_back(oshape);  // save output shape
 #if MXNET_USE_MKLDNN == 1
     if (MKLDNNRequireWorkspace(param_) && SupportMKLDNNPooling(param_))
-      out_shape->push_back(oshape); // for workspace
+      out_shape->push_back(oshape);   // for workspace
 #endif
   } else if (param_.kernel.ndim() == 2) {
     CHECK_EQ(dshape.ndim(), 4U)
@@ -153,7 +153,7 @@ static bool PoolingShape(const nnvm::NodeAttrs &attrs,
     out_shape->push_back(oshape);  // save output shape
 #if MXNET_USE_MKLDNN == 1
     if (MKLDNNRequireWorkspace(param_) && SupportMKLDNNPooling(param_))
-      out_shape->push_back(oshape); // for workspace
+      out_shape->push_back(oshape);   // for workspace
 #endif
   } else if (param_.kernel.ndim() == 3) {
     CHECK_EQ(dshape.ndim(), 5U)
@@ -199,7 +199,7 @@ static bool PoolingShape(const nnvm::NodeAttrs &attrs,
     out_shape->push_back(oshape);  // save output shape
 #if MXNET_USE_MKLDNN == 1
     if (MKLDNNRequireWorkspace(param_) && SupportMKLDNNPooling(param_))
-      out_shape->push_back(oshape); // for workspace
+      out_shape->push_back(oshape);   // for workspace
 #endif
   }
   return true;
@@ -223,7 +223,6 @@ void PoolingCompute_CPU(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
     return;
   }
 #endif
-  // TODO I need to convert format.
   std::vector<TBlob> in_blobs(inputs.size());
   for (size_t i = 0; i < in_blobs.size(); i++) in_blobs[i] = inputs[i].data();
   // We know pooling has only one output.
@@ -249,8 +248,7 @@ void PoolingGradCompute_CPU(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
     CHECK_EQ(inputs.size(), 5U);
     in_data = &inputs[2];
     workspace = &inputs[4];
-  }
-  else {
+  } else {
     CHECK_EQ(inputs.size(), 3U);
     in_data = &inputs[1];
   }
@@ -262,19 +260,17 @@ void PoolingGradCompute_CPU(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
     return;
   }
 #endif
-  // TODO I need to convert format.
   std::vector<TBlob> in_blobs(3);
   // In this case, there isn't workspace in the input arrays.
   if (inputs.size() == 3) {
     for (size_t i = 0; i < in_blobs.size(); i++)
       in_blobs[i] = inputs[i].data();
-  }
-  else {
+  } else {
     // There is workspace among the input arrays. One for out_grad and one for
     // input.
-    in_blobs[0] = inputs[0].data(); // out grad
-    in_blobs[1] = inputs[2].data(); // in data
-    in_blobs[2] = inputs[3].data(); // out data
+    in_blobs[0] = inputs[0].data();   // out grad
+    in_blobs[1] = inputs[2].data();   // in data
+    in_blobs[2] = inputs[3].data();   // out data
   }
   std::vector<TBlob> out_blobs(outputs.size());
   for (size_t i = 0; i < out_blobs.size(); i++)

--- a/src/operator/tensor/elemwise_binary_op_basic.cc
+++ b/src/operator/tensor/elemwise_binary_op_basic.cc
@@ -41,12 +41,11 @@ static void ElemwiseAddEx(const nnvm::NodeAttrs& attrs,
       || inputs[1].storage_type() == kMKLDNNStorage) {
     MKLDNNSum_Forward(attrs, ctx, inputs, req[0], outputs[0]);
     return;
-  }
-  // This happens if inputs are supposed to be in MKLDNN format
-  // but MKLDNN doesn't support the data type or the shape. We're
-  // forced to convert it to the default format.
-  else if (inputs[0].storage_type() == kDefaultStorage
-           || inputs[1].storage_type() == kDefaultStorage) {
+  } else if (inputs[0].storage_type() == kDefaultStorage
+             || inputs[1].storage_type() == kDefaultStorage) {
+    // This happens if inputs are supposed to be in MKLDNN format
+    // but MKLDNN doesn't support the data type or the shape. We're
+    // forced to convert it to the default format.
     std::vector<TBlob> in_blobs(2);
     std::vector<TBlob> out_blobs(1);
     in_blobs[0] = inputs[0].data();
@@ -74,10 +73,10 @@ static inline bool ElemwiseAddStorageType(const nnvm::NodeAttrs& attrs,
     out_attrs->at(0) = kMKLDNNStorage;
     *dispatch_mode = DispatchMode::kFComputeEx;
     return true;
-  } else
+  }
 #endif
-    return ElemwiseStorageType<2, 1, true, true, true>(attrs, dev_mask, dispatch_mode,
-                                                       in_attrs, out_attrs);
+  return ElemwiseStorageType<2, 1, true, true, true>(attrs, dev_mask, dispatch_mode,
+                                                     in_attrs, out_attrs);
 }
 
 MXNET_OPERATOR_REGISTER_BINARY(elemwise_add)
@@ -115,10 +114,11 @@ static void _backward_ElemwiseAddEx(const nnvm::NodeAttrs& attrs,
   if (inputs[0].storage_type() == kMKLDNNStorage) {
     MKLDNNCopy(attrs, ctx, inputs[0], req[0], outputs[0]);
     MKLDNNCopy(attrs, ctx, inputs[0], req[1], outputs[1]);
-  } else
+    return;
+  }
 #endif
-    ElemwiseBinaryOp::BackwardUseNoneEx<cpu, mshadow_op::identity, mshadow_op::identity>(
-        attrs, ctx, inputs, req, outputs);
+  ElemwiseBinaryOp::BackwardUseNoneEx<cpu, mshadow_op::identity, mshadow_op::identity>(
+      attrs, ctx, inputs, req, outputs);
 }
 
 static inline bool _backward_ElemwiseAddStorageType(const nnvm::NodeAttrs& attrs,
@@ -134,10 +134,10 @@ static inline bool _backward_ElemwiseAddStorageType(const nnvm::NodeAttrs& attrs
     out_attrs->at(1) = kMKLDNNStorage;
     *dispatch_mode = DispatchMode::kFComputeEx;
     return true;
-  } else
+  }
 #endif
-    return ElemwiseStorageType<1, 2, true, true, true>(attrs, dev_mask, dispatch_mode,
-                                                       in_attrs, out_attrs);
+  return ElemwiseStorageType<1, 2, true, true, true>(attrs, dev_mask, dispatch_mode,
+                                                     in_attrs, out_attrs);
 }
 
 NNVM_REGISTER_OP(_backward_add)

--- a/src/operator/tensor/elemwise_binary_scalar_op_basic.cc
+++ b/src/operator/tensor/elemwise_binary_scalar_op_basic.cc
@@ -86,11 +86,12 @@ static bool BinaryScalarStorageType(const nnvm::NodeAttrs& attrs,
   const auto in_stype = in_attrs->at(0);
   auto &out_stype = out_attrs->at(0);
   bool dispatched = false;
-  if (!dispatched && (in_stype == kDefaultStorage
 #if MXNET_USE_MKLDNN == 1
-        || in_stype == kMKLDNNStorage
+  if (!dispatched && (in_stype == kDefaultStorage
+                      || in_stype == kMKLDNNStorage)) {
+#else
+  if (!dispatched && (in_stype == kDefaultStorage)) {
 #endif
-        )) {
     // dns -> dns
     dispatched = storage_type_assign(&out_stype, kDefaultStorage,
                                      dispatch_mode, DispatchMode::kFCompute);

--- a/src/operator/tensor/elemwise_binary_scalar_op_basic.cc
+++ b/src/operator/tensor/elemwise_binary_scalar_op_basic.cc
@@ -53,11 +53,12 @@ static bool BinaryScalarStorageTypeWithDenseResultStorageType(const NodeAttrs& a
                                                               std::vector<int>* in_attrs,
                                                               std::vector<int>* out_attrs)  {
   bool dispatched = false;
-  if (common::ContainsOnlyStorage(*in_attrs, kDefaultStorage,
 #if MXNET_USE_MKLDNN == 1
-        kMKLDNNStorage, nullptr
+  if (common::ContainsOnlyStorage(*in_attrs, kDefaultStorage,
+                                  kMKLDNNStorage, nullptr)) {
+#else
+  if (common::ContainsOnlyStorage(*in_attrs, kDefaultStorage)) {
 #endif
-        )) {
     dispatched = storage_type_assign(&out_attrs[0],
                                      kDefaultStorage,
                                      dispatch_mode,

--- a/src/operator/tensor/elemwise_unary_op_basic.cc
+++ b/src/operator/tensor/elemwise_unary_op_basic.cc
@@ -122,11 +122,10 @@ static void CopyEx(const nnvm::NodeAttrs& attrs,
   if (in_stype == kMKLDNNStorage) {
     MKLDNNCopy(attrs, ctx, inputs[0], req[0], outputs[0]);
     return;
-  }
-  // This happens if inputs are supposed to be in MKLDNN format
-  // but MKLDNN doesn't support the data type or the shape. We're
-  // forced to convert it to the default format.
-  else if (inputs[0].storage_type() == kDefaultStorage) {
+  } else if (inputs[0].storage_type() == kDefaultStorage) {
+    // This happens if inputs are supposed to be in MKLDNN format
+    // but MKLDNN doesn't support the data type or the shape. We're
+    // forced to convert it to the default format.
     std::vector<TBlob> in_blobs(1);
     std::vector<TBlob> out_blobs(1);
     in_blobs[0] = inputs[0].data();
@@ -150,10 +149,10 @@ static inline bool CopyStorageType(const nnvm::NodeAttrs& attrs,
     out_attrs->at(0) = kMKLDNNStorage;
     *dispatch_mode = DispatchMode::kFComputeEx;
     return true;
-  } else
+  }
 #endif
-    return ElemwiseStorageType<1, 1, false, true, true>(attrs, dev_mask, dispatch_mode,
-                                                        in_attrs, out_attrs);
+  return ElemwiseStorageType<1, 1, false, true, true>(attrs, dev_mask, dispatch_mode,
+                                                      in_attrs, out_attrs);
 }
 
 MXNET_OPERATOR_REGISTER_UNARY(_copy)

--- a/src/operator/tensor/matrix_op.cc
+++ b/src/operator/tensor/matrix_op.cc
@@ -130,16 +130,11 @@ static void FlattenEx(const nnvm::NodeAttrs& attrs,
                       const std::vector<NDArray>& outputs) {
   CHECK_EQ(inputs.size(), 1U);
   CHECK_EQ(outputs.size(), 1U);
+#if MXNET_USE_MKLDNN == 1
   const auto in_stype = inputs[0].storage_type();
   const auto out_stype = outputs[0].storage_type();
-#if MXNET_USE_MKLDNN == 1
   if (in_stype == kMKLDNNStorage) {
-    NDArray data = inputs[0];
-    if (data.shape().ndim() != 2) {
-      const TShape& oshape = outputs[0].shape();
-      data = data.ReshapeMKLDNN(mshadow::Shape2(oshape[0], oshape[1]));
-    }
-    MKLDNNCopy(attrs, ctx, data, req[0], outputs[0]);
+    MKLDNNCopy(attrs, ctx, inputs[0], req[0], outputs[0]);
     return;
   }
   // This happens if inputs are supposed to be in MKLDNN format

--- a/src/operator/tensor/matrix_op.cc
+++ b/src/operator/tensor/matrix_op.cc
@@ -136,11 +136,10 @@ static void FlattenEx(const nnvm::NodeAttrs& attrs,
   if (in_stype == kMKLDNNStorage) {
     MKLDNNCopy(attrs, ctx, inputs[0], req[0], outputs[0]);
     return;
-  }
-  // This happens if inputs are supposed to be in MKLDNN format
-  // but MKLDNN doesn't support the data type or the shape. We're
-  // forced to convert it to the default format.
-  else if (in_stype == kDefaultStorage) {
+  } else if (in_stype == kDefaultStorage) {
+    // This happens if inputs are supposed to be in MKLDNN format
+    // but MKLDNN doesn't support the data type or the shape. We're
+    // forced to convert it to the default format.
     std::vector<TBlob> in_blobs(1);
     std::vector<TBlob> out_blobs(1);
     in_blobs[0] = inputs[0].data();
@@ -163,10 +162,10 @@ static inline bool FlattenStorageType(const nnvm::NodeAttrs& attrs,
     out_attrs->at(0) = kMKLDNNStorage;
     *dispatch_mode = DispatchMode::kFComputeEx;
     return true;
-  } else
+  }
 #endif
-    return ElemwiseStorageType<1, 1, false, true, true>(attrs, dev_mask, dispatch_mode,
-                                                        in_attrs, out_attrs);
+  return ElemwiseStorageType<1, 1, false, true, true>(attrs, dev_mask, dispatch_mode,
+                                                      in_attrs, out_attrs);
 }
 
 NNVM_REGISTER_OP(Flatten)


### PR DESCRIPTION
## Description ##
Add mkldnn surport for concat, which passed unit test. First epoch of inception-bn has "Epoch[0] Train-accuracy=0.573438"

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [ ] For user-facing API changes, API doc string has been updated. For new C++ functions in header files, their functionalities and arguments are well-documented. 
- [ ] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
