### PR TITLE
OP primitive cache: use memory as signature for MKLDNN storage type

### DIFF
--- a/src/operator/nn/mkldnn/mkldnn_act.cc
+++ b/src/operator/nn/mkldnn/mkldnn_act.cc
@@ -141,7 +141,7 @@ static MKLDNNActForward &GetActForward(const ActivationParam& param,
   MKLDNNActSignature key(param);
   key.AddSign(ctx.is_train);
   key.AddSign(param.act_type);
-  key.AddSign(in_mem);
+  key.AddSign(in_data);
 
   auto it = fwds.find(key);
   if (it == fwds.end()) {

--- a/src/operator/nn/mkldnn/mkldnn_base-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_base-inl.h
@@ -313,9 +313,13 @@ class MKLDNNOpSignature {
   }
 
   void AddSign(const NDArray &arr) {
-    hash = hash * 2 + arr.dtype();
-    eles.push_back(arr.dtype());
-    AddSign(arr.shape());
+    if (arr.IsMKLDNN()) {
+      AddSign(*(arr.GetMKLDNNData()));
+    } else {
+      hash = hash * 2 + arr.dtype();
+      eles.push_back(arr.dtype());
+      AddSign(arr.shape());
+    }
   }
 
   void AddSign(const TShape &shape) {


### PR DESCRIPTION
## Description ##
For Convolution/FC OPs, we can use NDArray dims/shape to do primitive cache signature, for some other OPs, we need to consider memory layout also, to unify the interface, we would like all OPs to pass NDArray type to AddSign and AddSign function will convert NDArray to memory type and do signature. With this change, convolution/FC OPs will also use memory to do signature, from testing, we almost didn't see any increase for convolution primitive cache count (using NDArray vs using memory to do sign) so it probably should be ok to use memory to sign convolution also.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] For user-facing API changes, API doc string has been updated. For new C++ functions in header files, their functionalities and arguments are well-documented. 
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
