### PR TITLE
Add primitive caching for Pooling forward computation

### DIFF
--- a/src/operator/nn/pooling-inl.h
+++ b/src/operator/nn/pooling-inl.h
@@ -78,6 +78,16 @@ struct PoolingParam : public dmlc::Parameter<PoolingParam> {
     DMLC_DECLARE_FIELD(pad).set_default(TShape())
     .describe("Pad for pooling: (y, x) or (d, y, x). Defaults to no padding.");
   }
+
+  bool operator==(const PoolingParam& other) const {
+    return this->kernel             == other.kernel &&
+           this->stride             == other.stride &&
+           this->pad                == other.pad &&
+           this->pool_type          == other.pool_type &&
+           this->pooling_convention == other.pooling_convention &&
+           this->global_pool        == other.global_pool &&
+           this->cudnn_off          == other.cudnn_off;
+  }
 };
 
 /*

--- a/src/operator/nn/pooling.cc
+++ b/src/operator/nn/pooling.cc
@@ -221,10 +221,10 @@ static bool PoolingShape(const nnvm::NodeAttrs &attrs,
   return true;
 }
 
-void PoolingCompute_CPU(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
-                        const std::vector<NDArray> &inputs,
-                        const std::vector<OpReqType> &req,
-                        const std::vector<NDArray> &outputs) {
+void PoolingComputeCPU(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
+                       const std::vector<NDArray> &inputs,
+                       const std::vector<OpReqType> &req,
+                       const std::vector<NDArray> &outputs) {
 #if MXNET_USE_MKLDNN == 1
   const PoolingParam &param = nnvm::get<PoolingParam>(attrs.parsed);
   const NDArray *workspace = nullptr;
@@ -234,7 +234,7 @@ void PoolingCompute_CPU(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
   }
   if (SupportMKLDNN(inputs[0])
       && SupportMKLDNNPooling(param, inputs[0].shape())) {
-    MKLDNNPoolingForward(ctx, param, inputs[0], req[0], outputs[0],
+    MKLDNNPoolingCompute(ctx, param, inputs[0], req[0], outputs[0],
                          workspace);
     return;
   }
@@ -247,10 +247,10 @@ void PoolingCompute_CPU(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
   PoolingCompute<cpu>(attrs, ctx, in_blobs, req, out_blobs);
 }
 
-void PoolingGradCompute_CPU(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
-                            const std::vector<NDArray> &inputs,
-                            const std::vector<OpReqType> &req,
-                            const std::vector<NDArray> &outputs) {
+void PoolingGradComputeCPU(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
+                           const std::vector<NDArray> &inputs,
+                           const std::vector<OpReqType> &req,
+                           const std::vector<NDArray> &outputs) {
 #if MXNET_USE_MKLDNN == 1
   const PoolingParam &param = nnvm::get<PoolingParam>(attrs.parsed);
   const NDArray &out_grad = inputs[0];
@@ -270,8 +270,8 @@ void PoolingGradCompute_CPU(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
   const NDArray &in_grad = outputs[0];
   if (SupportMKLDNN(inputs[0])
       && SupportMKLDNNPooling(param, inputs[0].shape())) {
-    MKLDNNPoolingBackward(ctx, param, out_grad, *in_data, workspace,
-                          req[0], in_grad);
+    MKLDNNPoolingGradCompute(ctx, param, out_grad, *in_data, workspace,
+                             req[0], in_grad);
     return;
   }
 #endif
@@ -400,7 +400,7 @@ height, width)*.
 .set_attr<nnvm::FInferType>("FInferType", PoolingType)
 .set_attr<nnvm::FInferShape>("FInferShape", PoolingShape)
 .set_attr<FCompute>("FCompute<cpu>", PoolingCompute<cpu>)
-.set_attr<FComputeEx>("FComputeEx<cpu>", PoolingCompute_CPU)
+.set_attr<FComputeEx>("FComputeEx<cpu>", PoolingComputeCPU)
 .set_attr<nnvm::FGradient>("FGradient",
                            ElemwiseGradUseInOut{"_backward_Pooling"})
 .add_argument("data", "NDArray-or-Symbol",
@@ -428,7 +428,7 @@ NNVM_REGISTER_OP(_backward_Pooling)
                              BackwardPoolingStorageType)
 .set_attr_parser(PoolingParamParser)
 .set_attr<FCompute>("FCompute<cpu>", PoolingGradCompute<cpu>)
-.set_attr<FComputeEx>("FComputeEx<cpu>", PoolingGradCompute_CPU);
+.set_attr<FComputeEx>("FComputeEx<cpu>", PoolingGradComputeCPU);
 
 }  // namespace op
 }  // namespace mxnet


### PR DESCRIPTION
## Description ##
1. Add primitive caching for Pooling forward computation;
2. Enable Avg Pooling support
3. Fix coding style
4. Convergence is validated with cifar10 + ResNet50 (which has avg pooling layer).

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] For user-facing API changes, API doc string has been updated. For new C++ functions in header files, their functionalities and arguments are well-documented. 
- [ ] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
