### PR TITLE
Change avg pooling algorithm to pooling_avg_include_padding

### DIFF
--- a/src/operator/nn/mkldnn/mkldnn_pooling-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_pooling-inl.h
@@ -161,7 +161,7 @@ void MKLDNNPoolingFwd::Execute() {
 
 static inline bool SupportMKLDNNPooling(const PoolingParam &param) {
   return param.kernel.ndim() == 2
-      && param.pool_type == pool_enum::kMaxPooling;
+      && (param.pool_type == pool_enum::kMaxPooling || param.pool_type == pool_enum::kAvgPooling);
 }
 
 static inline bool SupportMKLDNNPooling(const PoolingParam &param,
@@ -185,7 +185,7 @@ GetMKLDNNPoolAlgo(const PoolingParam &param) {
       return mkldnn::algorithm::pooling_max;
       break;
     case pool_enum::kAvgPooling:
-      return mkldnn::algorithm::pooling_avg;
+      return mkldnn::algorithm::pooling_avg_include_padding;
       break;
     default:
       LOG(FATAL) << "MKLDNN Pooling: Unknown pooling method.";


### PR DESCRIPTION
## Description ##
Since the default algorithm for avg pooling in MKL-DNN excludes padding (mkldnn_pooling_avg_exclude_padding). 
Change it to include padding (mkldnn_pooling_avg_include_padding).

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] For user-facing API changes, API doc string has been updated. For new C++ functions in header files, their functionalities and arguments are well-documented. 
- [ ] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
