### PR TITLE
Fix MKLDNN compile failure issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,9 @@ endif
 
 ifeq ($(USE_MKLDNN), 1)
 	RETURN_STRING := $(shell ./prepare_mkldnn.sh $(MKLDNN_ROOT))
-	MKLDNNROOT := $(firstword $(RETURN_STRING))
+	LAST_WORD_INDEX := $(words $(RETURN_STRING))
+	# fetch the 2nd last word as MKLDNNROOT
+	MKLDNNROOT := $(word $(shell echo $$(($(LAST_WORD_INDEX) - 1))),$(RETURN_STRING))
 	MKLROOT := $(lastword $(RETURN_STRING))
 	export USE_MKLML = 1
 endif

--- a/prepare_mkldnn.sh
+++ b/prepare_mkldnn.sh
@@ -77,19 +77,19 @@ if [ ! -f "$MKLDNN_INSTALLDIR/lib/libmkldnn.so" ]; then
     mkdir -p $MKLDNN_INSTALLDIR
 	cd $MKLDNN_ROOTDIR
     if [ -z $MKLROOT ] && [ ! -f $MKLDNN_INSTALLDIR/include/mkl_cblas.h ]; then
-        rm -rf external && cd scripts && ./prepare_mkl.sh && cd ..
+        rm -rf external && cd scripts && ./prepare_mkl.sh >&2 && cd ..
         cp -a external/*/* $MKLDNN_INSTALLDIR/.
     fi 
     echo "Building MKLDNN ..." >&2
     cd $MXNET_ROOTDIR
 	g++ --version >&2
     if [ -z $ARCH_OPT ]; then
-        cmake $MKLDNN_ROOTDIR -DCMAKE_INSTALL_PREFIX=$MKLDNN_INSTALLDIR -B$MKLDNN_BUILDDIR
+        cmake $MKLDNN_ROOTDIR -DCMAKE_INSTALL_PREFIX=$MKLDNN_INSTALLDIR -B$MKLDNN_BUILDDIR >&2
     else
-        cmake $MKLDNN_ROOTDIR -DCMAKE_INSTALL_PREFIX=$MKLDNN_INSTALLDIR -B$MKLDNN_BUILDDIR -DARCH_OPT_FLAGS=$ARCH_OPT
+        cmake $MKLDNN_ROOTDIR -DCMAKE_INSTALL_PREFIX=$MKLDNN_INSTALLDIR -B$MKLDNN_BUILDDIR -DARCH_OPT_FLAGS=$ARCH_OPT >&2
     fi
     make -C $MKLDNN_BUILDDIR -j$(cat /proc/cpuinfo | grep processor | wc -l) VERBOSE=1 >&2
-    make -C $MKLDNN_BUILDDIR install
+    make -C $MKLDNN_BUILDDIR install >&2
     rm -rf $MKLDNN_BUILDDIR
     mkdir -p $MKLDNN_LIBDIR
     cp $MKLDNN_INSTALLDIR/lib/* $MKLDNN_LIBDIR


### PR DESCRIPTION
## Description ##
Fix MKLDNN build failure issue, currently MKLDNN build will fail for the 1st time, this is due to prepare_mkldnn.sh will return massive unexpected output (due to cmake/compile/install) to Makefile and makes MKLDNNROOT assigned with wrong value. The fix is to suppress the unwanted log and fetch the 2nd last string from output as MKLDNNROOT so it would be safer.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [ ] For user-facing API changes, API doc string has been updated. For new C++ functions in header files, their functionalities and arguments are well-documented. 
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
