### PR TITLE
Remove simd from openmp instructions in BatchNorm

### DIFF
--- a/src/operator/nn/mkldnn/mkldnn_batch_norm-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_batch_norm-inl.h
@@ -234,20 +234,20 @@ void MKLDNNBatchNormForward(const OpContext &ctx, const BatchNormParam &param,
     DType* weight_ptr = gamma.data().dptr<DType>();
     DType* bias_ptr = beta.data().dptr<DType>();
     if (!param.fix_gamma) {
-#pragma omp parallel for simd
+#pragma omp parallel for
       for (int i = 0; i < channels_; i++) {
         weight_buf[i] = weight_ptr[i];
         weight_buf[channels_ + i] = bias_ptr[i];  // bias
       }
     } else if (IsBNWriting(req[batchnorm::kGamma])) {
-#pragma omp parallel for simd
+#pragma omp parallel for
       for (int i = 0; i < channels_; i++) {
         weight_buf[i] = (DType)1.0f;
         weight_ptr[i] = (DType)1.0f;
         weight_buf[channels_ + i] = bias_ptr[i];  // bias
       }
     } else {
-#pragma omp parallel for simd
+#pragma omp parallel for
       for (int i = 0; i < channels_; i++) {
         weight_buf[i] = (DType)1.0f;
         weight_buf[channels_ + i] = bias_ptr[i];  // bias
@@ -260,7 +260,7 @@ void MKLDNNBatchNormForward(const OpContext &ctx, const BatchNormParam &param,
       DType* inmean   = aux_states[batchnorm::kMovingMean].data().dptr<DType>();
       DType* invar    = aux_states[batchnorm::kMovingVar].data().dptr<DType>();
       // to align with origin implmentation: batch_norm.cc: L164
-#pragma omp parallel for simd
+#pragma omp parallel for
       for (int i = 0; i < channels_; i++) {
         omean[i] = inmean[i];
         ovar[i] = VARIANCE_TO_INVSTD(invar[i], param.eps);
@@ -282,7 +282,7 @@ void MKLDNNBatchNormForward(const OpContext &ctx, const BatchNormParam &param,
       MKLDNNStream::Get()->Submit();
       DType* mean_mem_ptr = reinterpret_cast<DType*>(fwd.GetMean().get_data_handle());
       DType* var_mem_ptr  = reinterpret_cast<DType*>(fwd.GetVar().get_data_handle());
-#pragma omp parallel for simd
+#pragma omp parallel for
       for (int i = 0; i < channels_; i++) {
         omean[i] = mean_mem_ptr[i];
         ovar[i]  = VARIANCE_TO_INVSTD(var_mem_ptr[i], param.eps);


### PR DESCRIPTION
## Description ##
To support GCC < 4.9.x, simd clause are removed from openmp instructions in mkldnn_batch_norm-inl.h file.
Code is tested on SKX and no performance regression is induced.
Style of openmp instruction is aligned to other uses in mxnet. Please kindly find them here:
https://github.com/zheng-da/incubator-mxnet/blob/mkldnn/src/operator/nn/softmax-inl.h#L64
https://github.com/zheng-da/incubator-mxnet/blob/mkldnn/src/operator/nn/batch_norm.cc#L118

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] For user-facing API changes, API doc string has been updated. For new C++ functions in header files, their functionalities and arguments are well-documented. 
- [ ] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
